### PR TITLE
namurthy/cherry-picking

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ those changes.
 Originally, we were waiting in hope the elodina maintainer would return, but it
 hasn't happened, so the plan now is to proceed with this as its own library and
 take PRs, push for feature additions and version bumps.
+

--- a/errors.go
+++ b/errors.go
@@ -39,6 +39,12 @@ var ErrBlockNotFinished = errors.New("Block read is unfinished")
 // Happens when avro schema contains invalid value for fixed size.
 var ErrInvalidFixedSize = errors.New("Invalid Fixed type size")
 
+// Happens when logicalType = decimal, but no precision specified
+var ErrPrecisionRequired = errors.New("precision is required in decimal logicalType")
+
+// Happens when avro schema contains invalid value for map value type or array item type.
+var ErrInvalidValueType = errors.New("Invalid array or map value type")
+
 //// Happens when avro schema contains a union within union.
 //var ErrNestedUnionsNotAllowed = errors.New("Nested unions are not allowed")
 

--- a/schema.go
+++ b/schema.go
@@ -203,18 +203,30 @@ func (bs *BytesSchema) MarshalJSON() ([]byte, error) {
 	if bs.LogicalType == "" {
 		return []byte(`"bytes"`), nil
 	}
-	// the only logical type on bytes is decimal
-	return json.Marshal(struct {
-		Type        string `json:"type"`
-		LogicalType string `json:"logicalType"`
-		Scale       int    `json:"scale"`
-		Precision   int    `json:"precision"`
-	}{
-		Type:        "long",
-		LogicalType: bs.LogicalType,
-		Scale:       bs.Scale,
-		Precision:   bs.Precision,
-	})
+	if bs.LogicalType == logicalTypeDecimal {
+		// the only logical type on bytes is decimal
+		return json.Marshal(struct {
+			Type        string `json:"type"`
+			LogicalType string `json:"logicalType"`
+			Scale       int    `json:"scale"`
+			Precision   int    `json:"precision"`
+		}{
+			Type:        "bytes",
+			LogicalType: bs.LogicalType,
+			Scale:       bs.Scale,
+			Precision:   bs.Precision,
+		})
+	} else {
+		// otherwise who knows?
+		// the only logical type on bytes is decimal
+		return json.Marshal(struct {
+			Type        string `json:"type"`
+			LogicalType string `json:"logicalType"`
+		}{
+			Type:        "bytes",
+			LogicalType: bs.LogicalType,
+		})
+	}
 }
 
 // IntSchema implements Schema and represents Avro int type.


### PR DESCRIPTION
Cherry picking of commits from another remote repo that adds support for logical types.
```
nmurthy:avro% go test ./...
ok  	github.com/teslamotors/avro	0.614s
?   	github.com/teslamotors/avro/codegen	[no test files]
?   	github.com/teslamotors/avro/examples/data_file	[no test files]
?   	github.com/teslamotors/avro/examples/generic_datum	[no test files]
?   	github.com/teslamotors/avro/examples/load_schema	[no test files]
?   	github.com/teslamotors/avro/examples/specific_datum	[no test files]
ok  	github.com/teslamotors/avro/fuzzes	0.514s
?   	github.com/teslamotors/avro/fuzzes/genericreader	[no test files]
```
Also just a note that 0d9f1f2 adds support for `Aliases` to `SchemaField` where as this library already has support for `Aliases` in `RecordSchema`.