### PR TITLE
Logical types binary marshaling for timestamp types

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ those changes.
 Originally, we were waiting in hope the elodina maintainer would return, but it
 hasn't happened, so the plan now is to proceed with this as its own library and
 take PRs, push for feature additions and version bumps.
+

--- a/datum_writer.go
+++ b/datum_writer.go
@@ -162,8 +162,7 @@ func (writer *SpecificDatumWriter) writeLong(v reflect.Value, enc Encoder, s Sch
 	if !s.Validate(v) {
 		return fmt.Errorf("Invalid long value: %v", v.Interface())
 	}
-
-	enc.WriteLong(v.Interface().(int64))
+	enc.WriteLong(s.(*LongSchema).GetInt64(v))
 	return nil
 }
 

--- a/datum_writer_test.go
+++ b/datum_writer_test.go
@@ -259,7 +259,7 @@ func TestSpecificDatumWriterLogicalTypes(t *testing.T) {
 	in := &Logical{
 		TimeMillis:      time.Unix(123456, int64(789*time.Millisecond)),
 		TimeMicros:      time.Unix(1234567890, int64(123456*time.Microsecond)),
-		TimeOfDayMicros: time.Unix(1234509876, int64(543210*time.Microsecond)),
+		TimeOfDayMicros: time.Unix(1234509876, int64(543210*time.Microsecond)).UTC(),
 	}
 
 	err = w.Write(in, enc)

--- a/errors.go
+++ b/errors.go
@@ -39,6 +39,12 @@ var ErrBlockNotFinished = errors.New("Block read is unfinished")
 // Happens when avro schema contains invalid value for fixed size.
 var ErrInvalidFixedSize = errors.New("Invalid Fixed type size")
 
+// Happens when logicalType = decimal, but no precision specified
+var ErrPrecisionRequired = errors.New("precision is required in decimal logicalType")
+
+// Happens when avro schema contains invalid value for map value type or array item type.
+var ErrInvalidValueType = errors.New("Invalid array or map value type")
+
 //// Happens when avro schema contains a union within union.
 //var ErrNestedUnionsNotAllowed = errors.New("Nested unions are not allowed")
 

--- a/schema.go
+++ b/schema.go
@@ -203,18 +203,30 @@ func (bs *BytesSchema) MarshalJSON() ([]byte, error) {
 	if bs.LogicalType == "" {
 		return []byte(`"bytes"`), nil
 	}
-	// the only logical type on bytes is decimal
-	return json.Marshal(struct {
-		Type        string `json:"type"`
-		LogicalType string `json:"logicalType"`
-		Scale       int    `json:"scale"`
-		Precision   int    `json:"precision"`
-	}{
-		Type:        "long",
-		LogicalType: bs.LogicalType,
-		Scale:       bs.Scale,
-		Precision:   bs.Precision,
-	})
+	if bs.LogicalType == logicalTypeDecimal {
+		// the only logical type on bytes is decimal
+		return json.Marshal(struct {
+			Type        string `json:"type"`
+			LogicalType string `json:"logicalType"`
+			Scale       int    `json:"scale"`
+			Precision   int    `json:"precision"`
+		}{
+			Type:        "bytes",
+			LogicalType: bs.LogicalType,
+			Scale:       bs.Scale,
+			Precision:   bs.Precision,
+		})
+	} else {
+		// otherwise who knows?
+		// the only logical type on bytes is decimal
+		return json.Marshal(struct {
+			Type        string `json:"type"`
+			LogicalType string `json:"logicalType"`
+		}{
+			Type:        "bytes",
+			LogicalType: bs.LogicalType,
+		})
+	}
 }
 
 // IntSchema implements Schema and represents Avro int type.


### PR DESCRIPTION
This adds (IMHO) binary marshaling for an important logical type - time.Time.  It's important because time fields are common in event data, and this representation is efficient to produce from the internal representation of a time in go.

- [x] SpecificDatumWriter - timestamp types excl. time.Duration/time-millis, time.Time/time-millis, time.Time/date
- [x] SpecificDatumReader - timestamp types

Here's the new test with some debugging output for illustration:

```
=== RUN   TestSpecificDatumWriterLogicalTypes
2018/08/08 10:49:12 Got for long (timestamp-millis): 1970-01-02 02:17:36.789 -0800 PST
2018/08/08 10:49:12 Writing: 123456789
2018/08/08 10:49:12 Got for long (timestamp-micros): 2009-02-13 15:31:30.123456 -0800 PST
2018/08/08 10:49:12 Writing: 1234567890123456
2018/08/08 10:49:12 Got for long (time-micros): 2009-02-13 07:24:36.54321 +0000 UTC
2018/08/08 10:49:12 Writing: 26676543210
2018/08/08 10:49:12 Converted timestamp-millis value 123456789 to 1970-01-02 02:17:36.789 -0800 PST
2018/08/08 10:49:12 Converted timestamp-micros value 1234567890123456 to 2009-02-13 15:31:30.123456 -0800 PST
2018/08/08 10:49:12 Converted time-micros value 26676543210 to 1970-01-01 07:24:36.54321 +0000 UTC
```