### PR TITLE
Add helpers for matching schemas

### DIFF
--- a/artisanal_json.go
+++ b/artisanal_json.go
@@ -1,0 +1,32 @@
+package avro
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+)
+
+/*
+ * this file contains a bunch of helper methods for writing bespoke JSON marshal functions.
+ */
+
+func writeFieldName(buf *bytes.Buffer, fieldname string, precedingComma bool) {
+	if precedingComma {
+		buf.WriteRune(',')
+	}
+	buf.WriteRune('"')
+	buf.WriteString(fieldname)
+	buf.WriteRune('"')
+	buf.WriteRune(':')
+}
+
+func writeInt(buf *bytes.Buffer, fieldname string, value int, precedingComma bool) {
+	writeFieldName(buf, fieldname, precedingComma)
+	buf.WriteString(strconv.FormatInt(int64(value), 10))
+}
+
+func writeString(buf *bytes.Buffer, fieldname, value string, precedingComma bool) {
+	writeFieldName(buf, fieldname, precedingComma)
+	formatted, _ := json.Marshal(value)
+	buf.Write(formatted)
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -35,6 +35,7 @@ func TestArraySchema(t *testing.T) {
 	if s.(*ArraySchema).Items.Type() != String {
 		t.Errorf("\n%s \n===\n Array item type should be STRING", raw)
 	}
+	stringArrayFingerprint := s.Fingerprint()
 
 	//array of longs
 	raw = `{"type":"array", "items": "long"}`
@@ -45,6 +46,9 @@ func TestArraySchema(t *testing.T) {
 	}
 	if s.(*ArraySchema).Items.Type() != Long {
 		t.Errorf("\n%s \n===\n Array item type should be LONG", raw)
+	}
+	if s.Fingerprint() == stringArrayFingerprint {
+		t.Errorf("\n%x \n===\n %x different schemas should have different fingerprints", stringArrayFingerprint, s.Fingerprint())
 	}
 
 	//array of arrays of strings
@@ -59,6 +63,9 @@ func TestArraySchema(t *testing.T) {
 	}
 	if s.(*ArraySchema).Items.(*ArraySchema).Items.Type() != String {
 		t.Errorf("\n%s \n===\n Array's nested item type should be STRING", raw)
+	}
+	if s.(*ArraySchema).Items.Fingerprint() != stringArrayFingerprint {
+		t.Errorf("\n%x \n!==\n %x matching schemas should have matching fingerprints", s.(*ArraySchema).Items.Fingerprint(), stringArrayFingerprint)
 	}
 
 	raw = `{"type":"array", "items": {"type": "record", "name": "TestRecord", "fields": [
@@ -256,6 +263,12 @@ func TestFixedSchema(t *testing.T) {
 	}
 	if s.(*FixedSchema).Name != "md5" {
 		t.Errorf("\n%s \n===\n Fixed name should be md5. Actual %#v", raw, s.(*FixedSchema).Name)
+	}
+	md5fingerprint := s.Fingerprint()
+	s, err = ParseSchema(`{"type": "fixed", "doc": "md5 is a digest of an input message", "size": 16, "name": "md5"}`)
+	assert(t, err, nil)
+	if s.Fingerprint() != md5fingerprint {
+		t.Errorf("\n%x \n!==\n %x matching schemas should have matching fingerprints", s.Fingerprint(), md5fingerprint)
 	}
 }
 


### PR DESCRIPTION
Some support for getting canonical schemas and CRC64 fingerprints out of Avro schemas.  See [Canonical Form for Schemas](https://avro.apache.org/docs/1.8.2/spec.html#Parsing+Canonical+Form+for+Schemas) for more.